### PR TITLE
Collapsible character cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -303,6 +303,10 @@
                 </div>
 
                 <div id="inventory-card" class="mdc-card">
+                    <input id="inventory-card-toggle" class="card-collapse-toggle" type="checkbox" aria-hidden="true">
+                    <label for="inventory-card-toggle" class="card-collapse-icon">
+                        <i class="fas fa-chevron-down"></i>
+                    </label>
                     <h3>Inventory</h3>
                     <div class="items">
                         <div id="inventory-template" class="inventory-container">

--- a/index.html
+++ b/index.html
@@ -82,8 +82,11 @@
             <!-- Character Sheet Panel -->
             <div id="character-pane">
                 <div class="mdc-card">
+                    <input id="character-card-toggle" class="card-collapse-toggle" type="checkbox" aria-hidden="true">
+                    <label for="character-card-toggle" class="card-collapse-icon">
+                        <i class="fas fa-chevron-down"></i>
+                    </label>
                     <h3>Character</h3>
-
                     <div class="status-group">
                         <div>Name</div>
                         <div id="character-name" class="status-group">John Doe</div>
@@ -224,6 +227,10 @@
                 </div>
 
                 <div id="bond-card" class="mdc-card">
+                    <input id="bond-card-toggle" class="card-collapse-toggle" type="checkbox" aria-hidden="true">
+                    <label for="bond-card-toggle" class="card-collapse-icon">
+                        <i class="fas fa-chevron-down"></i>
+                    </label>
                     <h3>Bonds</h3>
                     <div class="track-container">
                         <div id="progress-track-template" class="progress-track">
@@ -254,12 +261,20 @@
                 </div>
 
                 <div id="progress-card" class="mdc-card">
+                    <input id="progress-card-toggle" class="card-collapse-toggle" type="checkbox" aria-hidden="true">
+                    <label for="progress-card-toggle" class="card-collapse-icon">
+                        <i class="fas fa-chevron-down"></i>
+                    </label>
                     <h3>Progress</h3>
                     <div class="tracks">
                     </div>
                 </div>
 
                 <div id="asset-card" class="mdc-card">
+                    <input id="asset-card-toggle" class="card-collapse-toggle" type="checkbox" aria-hidden="true">
+                    <label for="asset-card-toggle" class="card-collapse-icon">
+                        <i class="fas fa-chevron-down"></i>
+                    </label>
                     <h3>Assets</h3>
                     <div class="assets">
                         <div id="asset-template" class="asset-container">

--- a/style.css
+++ b/style.css
@@ -120,6 +120,10 @@ body {
     align-items: flex-start;
 }
 
+#container .mdc-card {
+    position: relative;
+}
+
 /* Character sheet style */
 #character-pane {
     min-width: 355px;
@@ -136,6 +140,34 @@ body {
 #character-pane hr {
     width: 100%;
     border: 0.5px solid lightgray;
+}
+
+.mdc-card .card-collapse-icon {
+    cursor: pointer;
+    padding: 1em;
+    opacity: 0%;
+    position: absolute;
+    right: 0;
+    top: 0;
+    transition: all 0.1s ease-out;
+}
+
+.mdc-card:hover .card-collapse-icon {
+    opacity: 100%;
+}
+
+.mdc-card .card-collapse-toggle {
+    display: none;
+}
+
+.card-collapse-toggle:checked ~ .card-collapse-icon {
+    transform: rotate(-90deg) translateX(3px) translateY(-1px);
+}
+
+.card-collapse-toggle:checked ~ hr,
+.card-collapse-toggle:checked ~ div,
+.card-collapse-toggle:checked ~ ul {
+    display: none;
 }
 
 .status-group {


### PR DESCRIPTION
Implements #4 

![Screenshot 2020-01-04 10 59 01](https://user-images.githubusercontent.com/142862/71770447-65e13a00-2ee1-11ea-9d00-5e4a01ae1434.jpg)

Had wanted to use the `<details>` tag for this, but the polyfill for Edge broke MDC. Opted for the hidden checkbox technique instead.