### PR TITLE
Default Item quantity bugfix

### DIFF
--- a/js/state.js
+++ b/js/state.js
@@ -166,7 +166,7 @@ class InventoryItem extends Resource {
     /**
      * @param {string} name
      */
-    constructor(name, quantity) {
+    constructor(name, quantity = 1) {
         super(name);
 
         let quantityProp = new ResourceProperty();


### PR DESCRIPTION
Fixes a bug introduced [here](https://github.com/SHiLLySiT/IronWriter/commit/3a3c1152377ed4bed020a1eb2a0598f1459d1cae#diff-edc7940361ad2dfd03ad683b8c808216L161) that was setting the default item quantity to `undefined` instead of `1` as expected.